### PR TITLE
Adds setup configuration namespace options

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,6 +20,7 @@ class auditbeat::config {
     'logging'                   => $auditbeat::logging,
     'output'                    => $auditbeat::outputs,
     'processors'                => $auditbeat::processors,
+    'setup'                     => $auditbeat::setup,
     'auditbeat'                 => {
       'modules'                 => $auditbeat::modules,
     },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@
 # @param xpack the configuration of x-pack monitoring.
 # @param modules the required modules to load.
 # @param processors the optional processors for events enhancement.
+# @param setup the configuration of the setup namespace (kibana, dashboards, template, etc.)
 #
 class auditbeat (
   String $beat_name                                                   = $::hostname,
@@ -88,6 +89,7 @@ class auditbeat (
   Optional[Array[Hash]] $modules                                                      = undef,
   Optional[Array[Hash]] $processors                                                   = undef,
   Optional[Hash] $xpack                                                               = undef,
+  Optional[Hash] $setup                                                               = undef,
 ) {
 
   contain auditbeat::repo


### PR DESCRIPTION
Adds support for configuration options starting with `setup`, like [elasticsearch template loading](https://www.elastic.co/guide/en/beats/auditbeat/master/auditbeat-template.html) and [kibana dashboards](https://www.elastic.co/guide/en/beats/auditbeat/master/configuration-dashboards.html).