### PR TITLE
Apt update before package installation

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -20,6 +20,9 @@ class auditbeat::repo (
               source => 'https://artifacts.elastic.co/GPG-KEY-elasticsearch',
             },
           }
+          if $auditbeat::ensure == 'present' {
+            Class['apt::update'] -> Package['auditbeat']
+          }
         }
       }
       'RedHat': {


### PR DESCRIPTION
Hello

This commit fixes an ordering violation.
Specifically, executing apt update must precede package installation.

This is the error I get, when Puppet tries to install the package before invoking apt-update.

```
Notice: /Stage[main]/Auditbeat::Repo/Apt::Source[beats]/Apt::Setting[list-beats]/File[/etc/apt/sources.list.d/beats.list]/ensure: defined content as '{md5}0a61da7b2b9fab5f4a196d6c9dce66b7'
Error: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install auditbeat' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package auditbeat
Error: /Stage[main]/Auditbeat::Install/Package[auditbeat]/ensure: change from purged to latest failed: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install auditbeat' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package auditbeat
Notice: /Stage[main]/Auditbeat::Config/File[/etc/auditbeat/auditbeat.yml]: Dependency Package[auditbeat] has failures: true
Warning: /Stage[main]/Auditbeat::Config/File[/etc/auditbeat/auditbeat.yml]: Skipping because of failed dependencies
Notice: /Stage[main]/Auditbeat::Service/Service[auditbeat]: Dependency Package[auditbeat] has failures: true
Warning: /Stage[main]/Auditbeat::Service/Service[auditbeat]: Skipping because of failed dependencies
```

More details in the official documentation of puppetlabs-apt:
https://github.com/puppetlabs/puppetlabs-apt#adding-new-sources-or-ppas

> If you are adding a new source and trying to install packagesfrom the new source on the same Puppet run, your package resourceshould depend on Class[’apt::update’], as well as depending on theApt::Source resource”
