### PR TITLE
Support for all configuration options

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,18 +22,19 @@ class auditbeat::config {
     'output'                    => $auditbeat::outputs,
     'processors'                => $auditbeat::processors,
     'setup'                     => $auditbeat::setup,
-    'http'                      => $auditbeat::http,
     'auditbeat'                 => {
       'modules'                 => $auditbeat::modules,
     },
   })
+
+  $merged_config = deep_merge($auditbeat_config, $auditbeat::additional_config)
 
   file { '/etc/auditbeat/auditbeat.yml':
     ensure       => $auditbeat::ensure,
     owner        => 'root',
     group        => 'root',
     mode         => $auditbeat::config_file_mode,
-    content      => inline_template('<%= @auditbeat_config.to_yaml()  %>'),
+    content      => inline_template('<%= @merged_config.to_yaml()  %>'),
     validate_cmd => $validate_cmd,
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,7 @@ class auditbeat::config {
     'output'                    => $auditbeat::outputs,
     'processors'                => $auditbeat::processors,
     'setup'                     => $auditbeat::setup,
+    'http'                      => $auditbeat::http,
     'auditbeat'                 => {
       'modules'                 => $auditbeat::modules,
     },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,6 +95,7 @@ class auditbeat (
   Optional[Hash] $xpack                                                               = undef,
   Optional[Hash] $monitoring                                                          = undef,
   Optional[Hash] $setup                                                               = undef,
+  Optional[Hash] $http                                                                = undef,
 ) {
 
   contain auditbeat::repo

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,7 +95,7 @@ class auditbeat (
   Optional[Hash] $xpack                                                               = undef,
   Optional[Hash] $monitoring                                                          = undef,
   Optional[Hash] $setup                                                               = undef,
-  Optional[Hash] $http                                                                = undef,
+  Optional[Hash] $additional_config                                                   = {},
 ) {
 
   contain auditbeat::repo


### PR DESCRIPTION
We want to monitor auditbeat and would need the `http` configuration option for that.
Since this http Endpoint is an experimantal feature, it decided to implement this via an Optional `additional_config` Hash, which is merged with the default/remaining configuration Hash before writing it to `/etc/auditbeat/auditbeat.yml`. This change should also resolve Issues #4  and #7.
As they could then supply their configuration values to `additional_config`.