### PR TITLE
Service restart on update

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,14 +110,14 @@ class auditbeat (
 
   case $ensure {
     'present': {
-      -> Class['packetbeat::config']
-      -> Class['packetbeat::service']
+      -> Class['auditbeat::config']
+      -> Class['auditbeat::service']
 
-      Class['packetbeat::install']
-      ~> Class['packetbeat::service']
+      Class['auditbeat::install']
+      ~> Class['auditbeat::service']
 
-      Class['packetbeat::config']
-      ~> Class['packetbeat::service']
+      Class['auditbeat::config']
+      ~> Class['auditbeat::service']
     }
     default: {
       Class['auditbeat::service']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,9 +110,14 @@ class auditbeat (
 
   case $ensure {
     'present': {
-      Class['auditbeat::install']
-      ->Class['auditbeat::config']
-      ~>Class['auditbeat::service']
+      -> Class['packetbeat::config']
+      -> Class['packetbeat::service']
+
+      Class['packetbeat::install']
+      ~> Class['packetbeat::service']
+
+      Class['packetbeat::config']
+      ~> Class['packetbeat::service']
     }
     default: {
       Class['auditbeat::service']


### PR DESCRIPTION
The service does not restart when packetbeat is updated. Thus, the service has to be restarted manually before the new version is used. However, this should be done automatically after updating.