### PR TITLE
metadata allow puppetlabs/apt 11.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 2.0.0 < 9.4.0"
+      "version_requirement": ">= 2.0.0 < 12.0.0"
     },
     {
       "name": "puppet-zypprepo",


### PR DESCRIPTION
fix: 'norisnetwork-auditbeat' (v0.2.6) requires 'puppetlabs-apt' (>= 2.0.0 < 9.4.0)